### PR TITLE
feat: add taxi reservation form

### DIFF
--- a/src/routes/Taxi.tsx
+++ b/src/routes/Taxi.tsx
@@ -1,1 +1,279 @@
-export default () => <div className="page"><h1>예약 택시</h1></div>;
+import { useEffect, useMemo, useState } from "react";
+
+type Addr = {
+  x: string;
+  y: string;
+  roadAddress?: string;
+  jibunAddress?: string;
+};
+
+type AddressSuggestion = Addr & { label: string };
+
+type AddressAutocompleteProps = {
+  label: string;
+  placeholder: string;
+  selected: Addr | null;
+  onSelect: (addr: Addr | null) => void;
+};
+
+const labelOf = (addr: Addr | null) =>
+  addr?.roadAddress || addr?.jibunAddress || (addr ? `${addr.y}, ${addr.x}` : "");
+
+async function geocode(query: string): Promise<AddressSuggestion[]> {
+  if (query.trim().length < 2) return [];
+  const res = await fetch(`/api/geocode?query=${encodeURIComponent(query)}`);
+  const data = await res.json();
+  const addresses: Addr[] = data.addresses || [];
+  return addresses.map((addr) => ({ ...addr, label: labelOf(addr) }));
+}
+
+function AddressAutocomplete({ label, placeholder, selected, onSelect }: AddressAutocompleteProps) {
+  const [inputValue, setInputValue] = useState<string>(labelOf(selected));
+  const [suggestions, setSuggestions] = useState<AddressSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setInputValue(labelOf(selected));
+  }, [selected]);
+
+  useEffect(() => {
+    if (inputValue.trim().length < 2) {
+      setSuggestions([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    const handle = window.setTimeout(() => {
+      geocode(inputValue)
+        .then((list) => {
+          if (!cancelled) {
+            setSuggestions(list);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) setError("주소를 불러오지 못했습니다.");
+        })
+        .finally(() => {
+          if (!cancelled) setLoading(false);
+        });
+    }, 200);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(handle);
+    };
+  }, [inputValue]);
+
+  return (
+    <div className="field">
+      <label>
+        <span>{label}</span>
+        <input
+          type="text"
+          placeholder={placeholder}
+          value={inputValue}
+          onChange={(e) => {
+            setInputValue(e.target.value);
+            if (selected) onSelect(null);
+          }}
+        />
+      </label>
+      {selected && (
+        <button
+          type="button"
+          className="link-button"
+          onClick={() => {
+            setInputValue("");
+            onSelect(null);
+          }}
+        >
+          선택 해제
+        </button>
+      )}
+      {loading && <p className="hint">검색 중...</p>}
+      {error && <p className="error">{error}</p>}
+      {!loading && suggestions.length > 0 && (
+        <ul className="suggestions">
+          {suggestions.map((sug, idx) => (
+            <li key={`${sug.x}-${sug.y}-${idx}`}>
+              <button
+                type="button"
+                onClick={() => {
+                  onSelect(sug);
+                  setInputValue(sug.label);
+                  setSuggestions([]);
+                }}
+              >
+                {sug.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const km = (la1: number, lo1: number, la2: number, lo2: number) => {
+  const R = 6371;
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const dLat = toRad(la2 - la1);
+  const dLon = toRad(lo2 - lo1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(la1)) * Math.cos(toRad(la2)) * Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+};
+
+const estimateFare = (distanceKm: number) => 3800 + Math.max(0, distanceKm - 1.6) * 1000 * (100 / 132);
+
+export default function Taxi() {
+  const [pickup, setPickup] = useState<Addr | null>(null);
+  const [dropoff, setDropoff] = useState<Addr | null>(null);
+  const [rideDateTime, setRideDateTime] = useState<string>("");
+  const [passengers, setPassengers] = useState<string>("1");
+  const [memo, setMemo] = useState<string>("");
+  const [errors, setErrors] = useState<string[]>([]);
+  const [estimate, setEstimate] = useState<{ distance: number; fare: number } | null>(null);
+
+  const formattedPickup = useMemo(() => labelOf(pickup), [pickup]);
+  const formattedDropoff = useMemo(() => labelOf(dropoff), [dropoff]);
+
+  const validate = () => {
+    const validationErrors: string[] = [];
+    if (!pickup) validationErrors.push("출발지를 선택하세요.");
+    if (!dropoff) validationErrors.push("도착지를 선택하세요.");
+    if (!rideDateTime) validationErrors.push("탑승 일시를 입력하세요.");
+    const passengerNumber = Number(passengers);
+    if (!passengers || Number.isNaN(passengerNumber) || passengerNumber < 1) {
+      validationErrors.push("탑승 인원을 1명 이상으로 입력하세요.");
+    } else if (passengerNumber > 10) {
+      validationErrors.push("탑승 인원은 10명을 초과할 수 없습니다.");
+    }
+    if (memo.length > 200) validationErrors.push("메모는 200자 이내로 작성해주세요.");
+    setErrors(validationErrors);
+    return validationErrors.length === 0;
+  };
+
+  const handleEstimate = () => {
+    const hasAddressErrors = [] as string[];
+    if (!pickup) hasAddressErrors.push("출발지를 선택하세요.");
+    if (!dropoff) hasAddressErrors.push("도착지를 선택하세요.");
+    if (hasAddressErrors.length) {
+      setErrors(hasAddressErrors);
+      setEstimate(null);
+      return;
+    }
+    if (!pickup || !dropoff) return;
+    const distance = km(+pickup.y, +pickup.x, +dropoff.y, +dropoff.x);
+    const fare = estimateFare(distance);
+    setEstimate({ distance, fare });
+    setErrors([]);
+  };
+
+  const handleSubmit = () => {
+    if (!validate()) return;
+    if (!pickup || !dropoff) return;
+    const passengerNumber = Number(passengers);
+    const summary = [
+      `📍 출발지: ${formattedPickup}`,
+      `🏁 도착지: ${formattedDropoff}`,
+      `🕒 일시: ${new Date(rideDateTime).toLocaleString()}`,
+      `🧑‍🤝‍🧑 인원: ${passengerNumber}명`,
+      memo ? `📝 메모: ${memo}` : null,
+      estimate
+        ? `💰 예상 요금: 약 ${Math.round(estimate.fare).toLocaleString()}원 (거리 ${estimate.distance.toFixed(1)}km)`
+        : "💬 예상 요금 버튼으로 대략적인 요금을 확인할 수 있어요.",
+    ]
+      .filter(Boolean)
+      .join("\n");
+    window.alert(`예약 요청(데모)\n\n${summary}`);
+  };
+
+  return (
+    <div className="page taxi-page">
+      <h1>예약 택시</h1>
+      <div className="form">
+        <AddressAutocomplete
+          label="출발지"
+          placeholder="건물명, 도로명, 지번 등"
+          selected={pickup}
+          onSelect={setPickup}
+        />
+        <AddressAutocomplete
+          label="도착지"
+          placeholder="목적지 검색"
+          selected={dropoff}
+          onSelect={setDropoff}
+        />
+        <div className="field">
+          <label>
+            <span>탑승 일시</span>
+            <input
+              type="datetime-local"
+              value={rideDateTime}
+              onChange={(e) => setRideDateTime(e.target.value)}
+              min={new Date().toISOString().slice(0, 16)}
+            />
+          </label>
+        </div>
+        <div className="field">
+          <label>
+            <span>탑승 인원</span>
+            <input
+              type="number"
+              min={1}
+              max={10}
+              value={passengers}
+              onChange={(e) => setPassengers(e.target.value)}
+            />
+          </label>
+        </div>
+        <div className="field">
+          <label>
+            <span>요청 메모</span>
+            <textarea
+              placeholder="기사님께 전달할 내용을 작성하세요 (선택)"
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              rows={3}
+              maxLength={200}
+            />
+          </label>
+          <p className="hint">{memo.length}/200</p>
+        </div>
+        <div className="actions">
+          <button type="button" onClick={handleEstimate}>
+            요금 대략 보기
+          </button>
+          <button type="button" className="primary" onClick={handleSubmit}>
+            예약 요청(데모)
+          </button>
+        </div>
+        {errors.length > 0 && (
+          <div className="error-box" role="alert">
+            <ul>
+              {errors.map((error) => (
+                <li key={error}>{error}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+        {estimate && (
+          <div className="card estimate">
+            <h2>예상 요금 안내</h2>
+            <p>
+              거리 약 <strong>{estimate.distance.toFixed(1)} km</strong>
+            </p>
+            <p>
+              요금 약 <strong>{Math.round(estimate.fare).toLocaleString()}원</strong>
+            </p>
+            <p className="hint">실제 요금은 교통 상황 및 요금 정책에 따라 달라질 수 있어요.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,3 +35,24 @@ pre{white-space:pre-wrap;background:var(--card);padding:12px;border-radius:8px}
 .map-summary .guide p{margin:0;font-weight:600}
 .map-summary .guide .muted{font-size:13px}
 .map-preview{width:100%;border-radius:10px;margin-top:12px;box-shadow:0 10px 22px rgba(15,23,42,.12)}
+
+.page{padding:16px;max-width:720px;margin:0 auto}
+.page h1{margin-top:0;margin-bottom:16px}
+.page .form{display:flex;flex-direction:column;gap:16px}
+.page .field{display:flex;flex-direction:column;gap:8px}
+.page .field > label{display:flex;flex-direction:column;gap:8px;font-weight:600}
+.page .field span{font-size:14px;color:rgba(17,24,39,.85)}
+.page .actions{display:flex;flex-wrap:wrap;gap:10px}
+.page .actions .primary{background:#10b981}
+.page .hint{margin:0;font-size:12px;color:rgba(107,114,128,.9)}
+.page .error{margin:0;font-size:13px;color:#dc2626}
+.page .error-box{border:1px solid rgba(220,38,38,.4);background:#fef2f2;color:#b91c1c;padding:12px 14px;border-radius:10px}
+.page .error-box ul{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;font-size:14px}
+.page .suggestions{list-style:none;margin:0;padding:0;border:1px solid rgba(128,128,128,.35);border-radius:8px;overflow:hidden;background:var(--bg);box-shadow:0 8px 20px rgba(15,23,42,.12)}
+.page .suggestions li + li{border-top:1px solid rgba(128,128,128,.15)}
+.page .suggestions button{width:100%;text-align:left;background:transparent;color:var(--text);padding:10px 12px;font-weight:500}
+.page .suggestions button:hover{background:rgba(59,130,246,.08)}
+.page .link-button{align-self:flex-start;background:none;border:0;color:#2563eb;font-size:13px;padding:0;cursor:pointer}
+.page textarea{width:100%;padding:12px 14px;border-radius:8px;border:1px solid rgba(128,128,128,.35);background:transparent;color:var(--text)}
+.page .card.estimate h2{margin-top:0;margin-bottom:8px}
+.page .card.estimate p{margin:4px 0}


### PR DESCRIPTION
## Summary
- replace the taxi page with an interactive reservation form featuring address autocomplete and validation
- add distance-based fare estimation and demo reservation summary handling
- extend shared styles for form layout, suggestion list, and status feedback

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9965c5288331a8925421e2f34bb3