### PR TITLE
Add shared transit datasets and TypeScript bindings

### DIFF
--- a/data/bus_terminals.json
+++ b/data/bus_terminals.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "서울고속버스터미널",
+    "code": "KR-SEG",
+    "latitude": 37.504167,
+    "longitude": 127.004722,
+    "city": "서울",
+    "routes": ["경부선", "영동선", "호남선"],
+    "platforms": 60
+  },
+  {
+    "name": "센트럴시티터미널",
+    "code": "KR-CTR",
+    "latitude": 37.504389,
+    "longitude": 127.002111,
+    "city": "서울",
+    "routes": ["영동선", "호남선"],
+    "platforms": 45
+  },
+  {
+    "name": "부산종합버스터미널",
+    "code": "KR-BBT",
+    "latitude": 35.170278,
+    "longitude": 129.089722,
+    "city": "부산",
+    "routes": ["경부선", "중앙고속도로"],
+    "platforms": 41
+  }
+]

--- a/data/train_stations.json
+++ b/data/train_stations.json
@@ -1,0 +1,29 @@
+[
+  {
+    "name": "서울역",
+    "code": "KR-SEO",
+    "latitude": 37.554722,
+    "longitude": 126.970833,
+    "city": "서울",
+    "lines": ["경부선", "호남선", "공항철도"],
+    "opened": 1900
+  },
+  {
+    "name": "부산역",
+    "code": "KR-BUS",
+    "latitude": 35.115111,
+    "longitude": 129.041667,
+    "city": "부산",
+    "lines": ["경부선", "동해선"],
+    "opened": 1908
+  },
+  {
+    "name": "대전역",
+    "code": "KR-DAE",
+    "latitude": 36.3325,
+    "longitude": 127.434167,
+    "city": "대전",
+    "lines": ["경부선", "호남선"],
+    "opened": 1905
+  }
+]

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,0 +1,14 @@
+import trainStationsSource from '@data/train_stations.json'
+import busTerminalsSource from '@data/bus_terminals.json'
+
+import type { TrainStation, BusTerminal, TransitDataSet } from '../types/transit'
+
+export const trainStations = trainStationsSource as TrainStation[]
+export const busTerminals = busTerminalsSource as BusTerminal[]
+
+export const transitData: TransitDataSet = {
+  trainStations,
+  busTerminals
+}
+
+export type { TrainStation, BusTerminal }

--- a/src/types/transit.ts
+++ b/src/types/transit.ts
@@ -1,0 +1,26 @@
+export interface GeoPoint {
+  latitude: number
+  longitude: number
+}
+
+export interface TransitLocation extends GeoPoint {
+  name: string
+  code: string
+  city: string
+  address?: string
+}
+
+export interface TrainStation extends TransitLocation {
+  lines: string[]
+  opened?: number
+}
+
+export interface BusTerminal extends TransitLocation {
+  routes: string[]
+  platforms?: number
+}
+
+export type TransitDataSet = {
+  trainStations: TrainStation[]
+  busTerminals: BusTerminal[]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@data/*": ["data/*"]
+    }
+  },
+  "include": ["src", "data"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import { fileURLToPath, URL } from 'node:url'
+
 export default defineConfig({
   plugins: [react()],
   base: '/',
-  build: { outDir: 'dist' }
+  build: { outDir: 'dist' },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@data': fileURLToPath(new URL('./data', import.meta.url))
+    }
+  }
 })


### PR DESCRIPTION
## Summary
- add root-level transit datasets for train stations and bus terminals in JSON format
- provide shared transit type definitions and exports for reuse across modules
- configure TypeScript and Vite path aliases to consume the new JSON data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db99683b0883318df745c2c4524ccd