### PR TITLE
Fix Vite config object syntax

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,12 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+
 export default defineConfig({
   plugins: [react()],
   base: '/',
-  build: { outDir: 'dist' }
   publicDir: 'public',
   build: {
     outDir: 'dist',
-    copyPublicDir: true
-  }
+    copyPublicDir: true,
+  },
 })


### PR DESCRIPTION
## Summary
- rewrite the Vite configuration object so that publicDir and build.copyPublicDir are set with valid syntax

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db9fd1e8f083319f62ccc6ee3a1f62