### PR TITLE
Add theme-aware static map summary page

### DIFF
--- a/public/map-summary.css
+++ b/public/map-summary.css
@@ -1,0 +1,124 @@
+:root {
+  --bg: #ffffff;
+  --text: #111111;
+  --card: #f5f5f5;
+}
+[data-theme="dark"] {
+  --bg: #0b1526;
+  --text: #ffffff;
+  --card: #111a2e;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+}
+
+main.container {
+  padding: 16px;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1, h2, h3 {
+  color: var(--text);
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid rgba(128, 128, 128, 0.2);
+  border-radius: 12px;
+  padding: 18px;
+  margin-top: 16px;
+}
+
+.meta {
+  display: grid;
+  gap: 12px;
+  margin: 0;
+}
+
+.meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.meta dt {
+  font-size: 12px;
+  text-transform: uppercase;
+  color: rgba(128, 128, 128, 0.85);
+  letter-spacing: 0.08em;
+}
+
+.meta dd {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.alert {
+  margin: 16px 0 0;
+  padding: 12px 16px;
+  border-radius: 10px;
+  background: #fee2e2;
+  color: #b91c1c;
+  font-weight: 600;
+}
+
+.muted {
+  color: rgba(128, 128, 128, 0.85);
+  font-size: 14px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+section.guide-section {
+  margin-top: 16px;
+}
+
+ol.guide {
+  margin: 0;
+  padding-left: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+ol.guide li {
+  line-height: 1.5;
+}
+
+ol.guide p {
+  margin: 0;
+  font-weight: 600;
+}
+
+ol.guide .muted {
+  font-size: 13px;
+}
+
+.map-preview {
+  width: 100%;
+  border-radius: 10px;
+  margin-top: 12px;
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+}
+
+main.container.state-error {
+  max-width: 520px;
+}

--- a/public/map-summary.html
+++ b/public/map-summary.html
@@ -1,0 +1,64 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>네오퀵 · 경로 요약</title>
+    <link rel="stylesheet" href="/map-summary.css" />
+  </head>
+  <body>
+    <main class="container map-summary" data-role="container">
+      <h2>🗺️ 상세 경로 요약</h2>
+      <p class="muted" data-role="loading">경로 정보를 불러오는 중입니다...</p>
+      <p class="alert hidden" data-role="error"></p>
+
+      <section class="card" data-role="base">
+        <h3>기본 정보</h3>
+        <dl class="meta">
+          <div>
+            <dt>출발지</dt>
+            <dd data-field="start">-</dd>
+          </div>
+          <div>
+            <dt>도착지</dt>
+            <dd data-field="end">-</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card hidden" data-role="summary">
+        <h3>요약</h3>
+        <dl class="meta">
+          <div>
+            <dt>총 거리</dt>
+            <dd data-field="distance">-</dd>
+          </div>
+          <div>
+            <dt>예상 소요 시간</dt>
+            <dd data-field="duration">-</dd>
+          </div>
+          <div class="hidden" data-field-section="taxiFare">
+            <dt>예상 요금</dt>
+            <dd data-field="taxiFare">-</dd>
+          </div>
+          <div class="hidden" data-field-section="fuelPrice">
+            <dt>연료비</dt>
+            <dd data-field="fuelPrice">-</dd>
+          </div>
+        </dl>
+      </section>
+
+      <section class="card guide-section hidden">
+        <h3>이동 안내</h3>
+        <ol class="guide" data-role="guide"></ol>
+      </section>
+
+      <section class="card hidden" data-role="map-section">
+        <h3>지도 미리보기</h3>
+        <img class="map-preview" data-role="map-preview" alt="경로 미리보기 지도" />
+      </section>
+    </main>
+
+    <script type="module" src="/script/map-summary.js"></script>
+  </body>
+</html>

--- a/public/script/map-summary.js
+++ b/public/script/map-summary.js
@@ -1,0 +1,201 @@
+const savedTheme = typeof window !== "undefined" && window.localStorage ? window.localStorage.getItem("theme") : null;
+const prefersDark = typeof window !== "undefined" && window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)").matches : false;
+const activeTheme = savedTheme ?? (prefersDark ? "dark" : "light");
+if (typeof document !== "undefined") {
+  document.documentElement.setAttribute("data-theme", activeTheme);
+}
+
+const meterToReadable = (m) => {
+  if (!m && m !== 0) return "-";
+  if (m >= 1000) return `${(m / 1000).toFixed(1)} km`;
+  return `${Math.round(m)} m`;
+};
+
+const msToReadable = (ms) => {
+  if (!ms && ms !== 0) return "-";
+  const totalSec = Math.round(ms / 1000);
+  const hours = Math.floor(totalSec / 3600);
+  const minutes = Math.floor((totalSec % 3600) / 60);
+  const seconds = totalSec % 60;
+  const parts = [];
+  if (hours) parts.push(`${hours}시간`);
+  if (minutes) parts.push(`${minutes}분`);
+  if (!hours && !minutes) parts.push(`${seconds}초`);
+  return parts.join(" ") || "0초";
+};
+
+const formatCurrency = (n) => {
+  if (!n && n !== 0) return "-";
+  return `${Math.round(n).toLocaleString()}원`;
+};
+
+const selectAll = (selector) => Array.from(document.querySelectorAll(selector));
+const updateText = (key, value) => {
+  const targets = new Set([
+    ...selectAll(`[data-field="${key}"]`),
+    ...selectAll(`#${key}`)
+  ]);
+  targets.forEach((el) => {
+    if (el) {
+      el.textContent = value;
+    }
+  });
+};
+
+const showElement = (el, visible) => {
+  if (!el) return;
+  if (visible) {
+    el.removeAttribute("hidden");
+    el.classList.remove("hidden");
+  } else {
+    el.setAttribute("hidden", "hidden");
+    el.classList.add("hidden");
+  }
+};
+
+const label = (addr) => {
+  if (!addr) return "-";
+  return addr.roadAddress || addr.jibunAddress || `${addr.y}, ${addr.x}`;
+};
+
+const createGuideItem = (guide) => {
+  const li = document.createElement("li");
+  const primary = document.createElement("p");
+  primary.textContent = guide.instructions || "다음 안내";
+  li.append(primary);
+
+  const secondary = document.createElement("small");
+  secondary.className = "muted";
+  secondary.textContent = `${meterToReadable(guide.distance)} · ${msToReadable(guide.duration)}`;
+  li.append(secondary);
+  return li;
+};
+
+async function initialise() {
+  const container = document.querySelector("[data-role='container']") || document.body;
+  const loadingEl = document.querySelector("[data-role='loading']");
+  const errorEl = document.querySelector("[data-role='error']");
+  const guideList = document.querySelector("[data-role='guide']");
+  const summarySection = document.querySelector("[data-role='summary']");
+  const mapSection = document.querySelector("[data-role='map-section']");
+  const mapImg = document.querySelector("[data-role='map-preview']");
+
+  const startRaw = window.localStorage ? window.localStorage.getItem("start") : null;
+  const endRaw = window.localStorage ? window.localStorage.getItem("end") : null;
+
+  container.classList.remove("state-error");
+  if (errorEl) {
+    errorEl.textContent = "";
+    errorEl.classList.add("hidden");
+  }
+
+  if (!startRaw || !endRaw) {
+    if (errorEl) {
+      errorEl.textContent = "저장된 출발/도착 정보가 없습니다. 특송 경로 계산 화면에서 경로를 먼저 계산해주세요.";
+      showElement(errorEl, true);
+    }
+    showElement(loadingEl, false);
+    showElement(summarySection, false);
+    showElement(mapSection, false);
+    showElement(guideList?.closest("section"), false);
+    container.classList.add("state-error");
+    return;
+  }
+
+  try {
+    const parsedStart = JSON.parse(startRaw);
+    const parsedEnd = JSON.parse(endRaw);
+    updateText("start", label(parsedStart));
+    updateText("end", label(parsedEnd));
+
+    const params = new URLSearchParams({
+      startX: parsedStart.x,
+      startY: parsedStart.y,
+      endX: parsedEnd.x,
+      endY: parsedEnd.y
+    });
+
+    if (mapImg) {
+      mapImg.src = `/api/static-map?${params.toString()}`;
+      mapImg.alt = "경로 미리보기 지도";
+      showElement(mapSection, true);
+    }
+
+    try {
+      const res = await fetch(`/api/directions?${params.toString()}`);
+      if (!res.ok) {
+        throw new Error("경로 정보를 불러오지 못했습니다.");
+      }
+      const data = await res.json();
+      if (data.error) {
+        throw new Error(data.error);
+      }
+      const trafast = data.route?.trafast?.[0];
+      if (!trafast || !trafast.summary) {
+        throw new Error(data.message || "경로 요약 데이터를 찾을 수 없습니다.");
+      }
+
+      const summary = trafast.summary;
+      updateText("distance", meterToReadable(summary.distance));
+      updateText("duration", msToReadable(summary.duration));
+
+      const taxiRow = document.querySelector("[data-field-section='taxiFare']");
+      if (summary.taxiFare !== undefined) {
+        updateText("taxiFare", formatCurrency(summary.taxiFare));
+        showElement(taxiRow, true);
+      } else {
+        showElement(taxiRow, false);
+      }
+
+      const fuelRow = document.querySelector("[data-field-section='fuelPrice']");
+      if (summary.fuelPrice !== undefined) {
+        updateText("fuelPrice", formatCurrency(summary.fuelPrice));
+        showElement(fuelRow, true);
+      } else {
+        showElement(fuelRow, false);
+      }
+
+      if (Array.isArray(trafast.guide) && trafast.guide.length && guideList) {
+        guideList.innerHTML = "";
+        trafast.guide.forEach((guide) => {
+          guideList.append(createGuideItem(guide));
+        });
+        showElement(guideList.closest("section"), true);
+      } else if (guideList) {
+        guideList.innerHTML = "";
+        showElement(guideList.closest("section"), false);
+      }
+
+      showElement(summarySection, true);
+    } catch (err) {
+      console.error(err);
+      if (errorEl) {
+        const message = err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.";
+        errorEl.textContent = message;
+        showElement(errorEl, true);
+      }
+      showElement(summarySection, false);
+      showElement(guideList?.closest("section"), false);
+      showElement(mapSection, !!mapImg?.src);
+      container.classList.add("state-error");
+    }
+  } catch (err) {
+    console.error(err);
+    if (errorEl) {
+      errorEl.textContent = "저장된 위치 정보를 해석할 수 없습니다. 다시 경로를 계산해주세요.";
+      showElement(errorEl, true);
+    }
+    showElement(summarySection, false);
+    showElement(guideList?.closest("section"), false);
+    showElement(mapSection, false);
+    container.classList.add("state-error");
+  } finally {
+    showElement(loadingEl, false);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", initialise);
+} else {
+  initialise();
+}


### PR DESCRIPTION
## Summary
- add a standalone map-summary.html surface that mirrors the SPA layout for saved routes
- reuse the shared palette through map-summary.css and ensure cards/guide sections style correctly in both themes
- initialize data-theme from localStorage in map-summary.js before the page bootstrap so palette matches the SPA and populate route data with graceful error states

## Testing
- browser_container.run_playwright_script (manual theme toggle verification)


------
https://chatgpt.com/codex/tasks/task_e_68db9fd4669c83318a4ecf5ba93cb14f