### PR TITLE
Add Naver geocode integration to local suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # neoq0910
+
+## Environment variables
+
+The serverless functions rely on several third-party map providers. Set the following variables in your deployment environment:
+
+- `KAKAO_REST_KEY` – Kakao Local REST API key used for keyword and address search.
+- `NAVER_SEARCH_CLIENT_ID` / `NAVER_SEARCH_CLIENT_SECRET` – credentials for the Naver Local Search API.
+- `NAVER_GEOCODE_KEY_ID` / `NAVER_GEOCODE_KEY` – Naver Cloud Platform Map Geocode API credentials used to turn addresses into coordinates.
+- `MAPBOX_TOKEN` – Mapbox access token for geocoding fallbacks.


### PR DESCRIPTION
## Summary
- add a reusable helper that calls the Naver Map Geocode API with credentials from the environment
- geocode Naver Local search results so only entries with valid coordinates are returned while preserving deduplication
- document the environment variables required for Kakao, Naver, and Mapbox integrations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcb4435bc8833189564d7c2c984c98