### PR TITLE
Refine suggestion env typing and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ The serverless functions rely on several third-party map providers. Set the foll
 
 - `KAKAO_REST_KEY` – Kakao Local REST API key used for keyword and address search.
 - `NAVER_SEARCH_CLIENT_ID` / `NAVER_SEARCH_CLIENT_SECRET` – credentials for the Naver Local Search API.
-- `NAVER_GEOCODE_KEY_ID` / `NAVER_GEOCODE_KEY` – Naver Cloud Platform Map Geocode API credentials used to turn addresses into coordinates.
+- `NAVER_GEOCODE_KEY_ID` / `NAVER_GEOCODE_KEY` – Naver Cloud Platform Map Geocode API credentials used to turn addresses returned from Local Search into coordinates.
 - `MAPBOX_TOKEN` – Mapbox access token for geocoding fallbacks.


### PR DESCRIPTION
## Summary
- type the suggestion API environment and reuse it across helper functions
- ensure Naver local suggestions cache geocode lookups and skip failed coordinates
- clarify the README entry for the Naver geocode credentials

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb610b0b08331bb581f4986b64bd6