### PR TITLE
Add waypoint support to map summary view

### DIFF
--- a/functions/api/directions.ts
+++ b/functions/api/directions.ts
@@ -16,8 +16,14 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
 
     // ⚠️ Directions는 경도,위도(lon,lat) 순서
-    const api = `https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving`
-              + `?start=${sx},${sy}&goal=${ex},${ey}&option=trafast`;
+    const waypoints = u.searchParams.get("waypoints");
+
+    let api = `https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving`
+            + `?start=${sx},${sy}&goal=${ex},${ey}&option=trafast`;
+
+    if (waypoints) {
+      api += `&waypoints=${encodeURIComponent(waypoints)}`;
+    }
 
     const r = await fetch(api, {
       headers: {

--- a/functions/api/static-map.ts
+++ b/functions/api/static-map.ts
@@ -11,9 +11,20 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     const keyId  = (env.NAVER_CLIENT_ID || "").trim();
     const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
 
-    const api = `https://naveropenapi.apigw.ntruss.com/map-static/v2/raster?w=800&h=480&scale=2`
-              + `&markers=type:d|size:mid|pos:${sx} ${sy}|label:S`
-              + `&markers=type:d|size:mid|pos:${ex} ${ey}|label:E`;
+    const waypoints = (u.searchParams.get("waypoints") || "")
+      .split("|")
+      .map((pair) => pair.trim())
+      .filter(Boolean)
+      .map((pair) => pair.split(",", 2))
+      .filter(([wx, wy]) => wx && wy);
+
+    let api = `https://naveropenapi.apigw.ntruss.com/map-static/v2/raster?w=800&h=480&scale=2`
+            + `&markers=type:d|size:mid|pos:${sx} ${sy}|label:S`
+            + `&markers=type:d|size:mid|pos:${ex} ${ey}|label:E`;
+
+    waypoints.forEach(([wx, wy], idx) => {
+      api += `&markers=type:d|size:small|pos:${wx} ${wy}|label:${idx + 1}`;
+    });
 
     const r = await fetch(api, {
       headers: {

--- a/public/map-summary.html
+++ b/public/map-summary.html
@@ -20,6 +20,13 @@
             <dd data-field="start">-</dd>
           </div>
           <div>
+            <dt>경유지</dt>
+            <dd>
+              <ol class="waypoint-list" data-role="waypoints"></ol>
+              <span class="muted" data-role="waypoints-empty">없음</span>
+            </dd>
+          </div>
+          <div>
             <dt>도착지</dt>
             <dd data-field="end">-</dd>
           </div>

--- a/src/routes/ExpressPage.tsx
+++ b/src/routes/ExpressPage.tsx
@@ -134,7 +134,8 @@ export default function ExpressPage() {
     if (typeof window === "undefined") return;
     const savedStart = window.localStorage.getItem("start");
     const savedEnd = window.localStorage.getItem("end");
-    setHasSavedRoute(!!(savedStart && savedEnd));
+    const savedRoute = window.localStorage.getItem("route");
+    setHasSavedRoute(Boolean(savedRoute || (savedStart && savedEnd)));
   }, []);
 
   function confirm() {
@@ -147,6 +148,7 @@ export default function ExpressPage() {
     setMapUrl(`/api/static-map?startX=${sx}&startY=${sy}&endX=${ex}&endY=${ey}`);
     localStorage.setItem("start", JSON.stringify(start));
     localStorage.setItem("end", JSON.stringify(end));
+    localStorage.setItem("route", JSON.stringify({ start, end, waypoints: [] }));
     setHasSavedRoute(true);
   }
 

--- a/src/routes/MapSummary.tsx
+++ b/src/routes/MapSummary.tsx
@@ -1,8 +1,15 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 type Addr = { x: string; y: string; roadAddress?: string; jibunAddress?: string };
+type StoredRoute = { start: Addr; end: Addr; waypoints?: Addr[] | null };
 type TrafastSummary = { distance: number; duration: number; tollFare?: number; taxiFare?: number; fuelPrice?: number };
-type GuideEntry = { instructions?: string; distance?: number; duration?: number };
+type GuideEntry = {
+  instructions?: string;
+  distance?: number;
+  duration?: number;
+  pointIndex?: number;
+  type?: number;
+};
 
 type RoutePayload = {
   summary?: TrafastSummary;
@@ -42,9 +49,16 @@ const formatCurrency = (n?: number) => {
   return `${Math.round(n).toLocaleString()}원`;
 };
 
+const waypointQueryValue = (waypoints: Addr[]) =>
+  waypoints
+    .filter((wp) => wp && typeof wp.x === "string" && typeof wp.y === "string")
+    .map((wp) => `${wp.x},${wp.y}`)
+    .join("|");
+
 export default function MapSummary() {
   const [start, setStart] = useState<Addr | null>(null);
   const [end, setEnd] = useState<Addr | null>(null);
+  const [waypoints, setWaypoints] = useState<Addr[]>([]);
   const [summary, setSummary] = useState<TrafastSummary | null>(null);
   const [guide, setGuide] = useState<GuideEntry[]>([]);
   const [mapUrl, setMapUrl] = useState("");
@@ -52,60 +66,134 @@ export default function MapSummary() {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    const startRaw = typeof window !== "undefined" ? window.localStorage.getItem("start") : null;
-    const endRaw = typeof window !== "undefined" ? window.localStorage.getItem("end") : null;
+    const load = async () => {
+      try {
+        const routeRaw = typeof window !== "undefined" ? window.localStorage.getItem("route") : null;
+        const startRaw = typeof window !== "undefined" ? window.localStorage.getItem("start") : null;
+        const endRaw = typeof window !== "undefined" ? window.localStorage.getItem("end") : null;
 
-    if (!startRaw || !endRaw) {
-      setError("저장된 출발/도착 정보가 없습니다. 특송 경로 계산 화면에서 경로를 먼저 계산해주세요.");
-      setLoading(false);
-      return;
-    }
+        let storedRoute: StoredRoute | null = null;
 
-    try {
-      const parsedStart = JSON.parse(startRaw) as Addr;
-      const parsedEnd = JSON.parse(endRaw) as Addr;
-      setStart(parsedStart);
-      setEnd(parsedEnd);
-      const params = new URLSearchParams({
-        startX: parsedStart.x,
-        startY: parsedStart.y,
-        endX: parsedEnd.x,
-        endY: parsedEnd.y
-      });
-      const map = `/api/static-map?${params.toString()}`;
-      setMapUrl(map);
-
-      (async () => {
-        try {
-          const res = await fetch(`/api/directions?${params.toString()}`);
-          if (!res.ok) {
-            throw new Error("경로 정보를 불러오지 못했습니다.");
-          }
-          const data: DirectionsResponse = await res.json();
-          if (data.error) {
-            throw new Error(data.error);
-          }
-          const trafast = data.route?.trafast?.[0];
-          if (!trafast || !trafast.summary) {
-            throw new Error(data.message || "경로 요약 데이터를 찾을 수 없습니다.");
-          }
-          setSummary(trafast.summary);
-          setGuide(trafast.guide || []);
-          setLoading(false);
-        } catch (err) {
-          console.error(err);
-          setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.");
-          setLoading(false);
+        if (routeRaw) {
+          storedRoute = JSON.parse(routeRaw) as StoredRoute;
+        } else if (startRaw && endRaw) {
+          storedRoute = {
+            start: JSON.parse(startRaw) as Addr,
+            end: JSON.parse(endRaw) as Addr,
+            waypoints: []
+          };
         }
-      })();
-    } catch (err) {
-      console.error(err);
-      setError("저장된 위치 정보를 해석할 수 없습니다. 다시 경로를 계산해주세요.");
-      setLoading(false);
-    }
+
+        if (!storedRoute?.start || !storedRoute?.end) {
+          throw new Error("저장된 경로 정보를 찾을 수 없습니다. 특송 경로 계산 화면에서 경로를 먼저 계산해주세요.");
+        }
+
+        const parsedStart = storedRoute.start;
+        const parsedEnd = storedRoute.end;
+        const parsedWaypoints = Array.isArray(storedRoute.waypoints)
+          ? storedRoute.waypoints.filter((wp): wp is Addr => Boolean(wp))
+          : [];
+
+        setStart(parsedStart);
+        setEnd(parsedEnd);
+        setWaypoints(parsedWaypoints);
+
+        const params = new URLSearchParams({
+          startX: parsedStart.x,
+          startY: parsedStart.y,
+          endX: parsedEnd.x,
+          endY: parsedEnd.y
+        });
+
+        if (parsedWaypoints.length) {
+          params.set("waypoints", waypointQueryValue(parsedWaypoints));
+        }
+
+        setMapUrl(`/api/static-map?${params.toString()}`);
+
+        const res = await fetch(`/api/directions?${params.toString()}`);
+        if (!res.ok) {
+          throw new Error("경로 정보를 불러오지 못했습니다.");
+        }
+        const data: DirectionsResponse = await res.json();
+        if (data.error) {
+          throw new Error(data.error);
+        }
+        const trafast = data.route?.trafast?.[0];
+        if (!trafast || !trafast.summary) {
+          throw new Error(data.message || "경로 요약 데이터를 찾을 수 없습니다.");
+        }
+
+        setSummary(trafast.summary);
+        setGuide(trafast.guide || []);
+        setLoading(false);
+      } catch (err) {
+        console.error(err);
+        setError(err instanceof Error ? err.message : "알 수 없는 오류가 발생했습니다.");
+        setLoading(false);
+      }
+    };
+
+    load();
   }, []);
 
   const label = (a: Addr | null) => a?.roadAddress || a?.jibunAddress || (a ? `${a.y}, ${a.x}` : "-");
+  const waypointLabel = (a: Addr, idx: number) => `${idx + 1}. ${label(a)}`;
+
+  const segmentTitles = useMemo(() => {
+    if (!start || !end) return [] as string[];
+    const points = [start, ...waypoints, end];
+    const nameForIndex = (index: number) => {
+      if (index === 0) return "출발지";
+      if (index === points.length - 1) return "도착지";
+      return `경유지 ${index}`;
+    };
+    const titles: string[] = [];
+    for (let i = 0; i < points.length - 1; i += 1) {
+      titles.push(`${nameForIndex(i)} → ${nameForIndex(i + 1)}`);
+    }
+    return titles;
+  }, [start, end, waypoints]);
+
+  const decoratedGuide = useMemo(() => {
+    if (!guide.length) return [] as Array<{ type: "segment"; label: string } | { type: "entry"; entry: GuideEntry; key: number }>;
+
+    const items: Array<{ type: "segment"; label: string } | { type: "entry"; entry: GuideEntry; key: number }> = [];
+    if (segmentTitles[0]) {
+      items.push({ type: "segment", label: segmentTitles[0] });
+    }
+
+    let currentSegment = 0;
+    let waypointHitCount = 0;
+    const targetWaypointCount = waypoints.length;
+
+    const isWaypointArrival = (entry: GuideEntry) => {
+      if (waypointHitCount >= targetWaypointCount) return false;
+      if (entry.type === 3) return true;
+      const normalized = (entry.instructions || "").replace(/\s+/g, "");
+      if (!normalized) return false;
+      return /경유지|경유|passpoint|waypoint|중간지점/i.test(normalized);
+    };
+
+    guide.forEach((entry, index) => {
+      items.push({ type: "entry", entry, key: index });
+
+      if (isWaypointArrival(entry)) {
+        waypointHitCount += 1;
+        currentSegment += 1;
+        if (segmentTitles[currentSegment]) {
+          items.push({ type: "segment", label: segmentTitles[currentSegment] });
+        }
+      }
+    });
+
+    while (currentSegment < segmentTitles.length - 1) {
+      currentSegment += 1;
+      items.push({ type: "segment", label: segmentTitles[currentSegment] });
+    }
+
+    return items;
+  }, [guide, segmentTitles, waypoints.length]);
 
   return (
     <div className="container map-summary">
@@ -121,6 +209,20 @@ export default function MapSummary() {
               <div>
                 <dt>출발지</dt>
                 <dd>{label(start)}</dd>
+              </div>
+              <div>
+                <dt>경유지</dt>
+                <dd>
+                  {waypoints.length > 0 ? (
+                    <ol className="waypoint-list">
+                      {waypoints.map((wp, idx) => (
+                        <li key={`${wp.x}-${wp.y}-${idx}`}>{waypointLabel(wp, idx)}</li>
+                      ))}
+                    </ol>
+                  ) : (
+                    <span className="muted">없음</span>
+                  )}
+                </dd>
               </div>
               <div>
                 <dt>도착지</dt>
@@ -161,14 +263,20 @@ export default function MapSummary() {
             <section className="card">
               <h3>이동 안내</h3>
               <ol className="guide">
-                {guide.map((g, idx) => (
-                  <li key={idx}>
-                    <p>{g.instructions || "다음 안내"}</p>
-                    <small className="muted">
-                      {meterToReadable(g.distance)} · {msToReadable(g.duration)}
-                    </small>
-                  </li>
-                ))}
+                {decoratedGuide.map((item, idx) =>
+                  item.type === "segment" ? (
+                    <li key={`segment-${idx}`} className="guide-segment">
+                      <span>{item.label}</span>
+                    </li>
+                  ) : (
+                    <li key={`guide-${item.key}`}>
+                      <p>{item.entry.instructions || "다음 안내"}</p>
+                      <small className="muted">
+                        {meterToReadable(item.entry.distance)} · {msToReadable(item.entry.duration)}
+                      </small>
+                    </li>
+                  )
+                )}
               </ol>
             </section>
           )}

--- a/src/styles.css
+++ b/src/styles.css
@@ -30,10 +30,14 @@ pre{white-space:pre-wrap;background:var(--card);padding:12px;border-radius:8px}
 .map-summary .meta div{display:flex;flex-direction:column;gap:4px}
 .map-summary .meta dt{font-size:12px;text-transform:uppercase;color:rgba(128,128,128,.85);letter-spacing:.08em}
 .map-summary .meta dd{margin:0;font-size:16px;font-weight:600;color:var(--text)}
+.map-summary .waypoint-list{margin:0;padding-left:18px;display:flex;flex-direction:column;gap:4px;font-size:14px;font-weight:600;color:var(--text)}
 .map-summary .guide{margin:0;padding-left:20px;display:flex;flex-direction:column;gap:12px}
 .map-summary .guide li{line-height:1.5}
 .map-summary .guide p{margin:0;font-weight:600}
 .map-summary .guide .muted{font-size:13px}
+.map-summary .guide-segment{list-style:none;margin:0;padding:6px 0 2px;border-top:1px dashed rgba(128,128,128,.35);font-size:12px;letter-spacing:.05em;text-transform:uppercase;color:rgba(37,99,235,.9)}
+.map-summary .guide-segment:first-child{border-top:0;padding-top:0}
+.map-summary .guide-segment span{display:inline-block;padding:4px 10px;border-radius:999px;background:rgba(59,130,246,.12);color:#1d4ed8;font-weight:700;text-transform:none;letter-spacing:0}
 .map-preview{width:100%;border-radius:10px;margin-top:12px;box-shadow:0 10px 22px rgba(15,23,42,.12)}
 
 .page{padding:16px;max-width:720px;margin:0 auto}


### PR DESCRIPTION
## Summary
- load the stored route object in the map summary screen, render waypoint lists, and segment the guide between legs
- propagate waypoint coordinates when requesting directions and static maps, and persist the combined route from the calculator
- update the static summary page, shared styles, and API proxies so static maps and guidance stay in sync with waypoint routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb8c43d1c8331a4649d5d4c3d4f39