### PR TITLE
Add waypoint rendering to static map proxy

### DIFF
--- a/functions/api/static-map.ts
+++ b/functions/api/static-map.ts
@@ -7,13 +7,45 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     const ey = u.searchParams.get("endY");
     if (!sx || !sy || !ex || !ey) return new Response("Missing coords", { status: 400 });
 
+    const MAX_WAYPOINTS = 8;
+    const parseWaypoint = (value: string | null) => {
+      if (!value) return null;
+      const parts = value
+        .split(/[\s,]+/)
+        .map((part) => part.trim())
+        .filter(Boolean);
+      if (parts.length < 2) return null;
+      const [x, y] = parts;
+      return { x, y };
+    };
+
+    const waypoints = u.searchParams
+      .getAll("waypoints")
+      .map((value) => parseWaypoint(value))
+      .filter((v): v is { x: string; y: string } => Boolean(v))
+      .slice(0, MAX_WAYPOINTS);
+
     const origin = request.headers.get("Origin") || `${u.protocol}//${u.host}`;
     const keyId  = (env.NAVER_CLIENT_ID || "").trim();
     const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
 
-    const api = `https://naveropenapi.apigw.ntruss.com/map-static/v2/raster?w=800&h=480&scale=2`
-              + `&markers=type:d|size:mid|pos:${sx} ${sy}|label:S`
-              + `&markers=type:d|size:mid|pos:${ex} ${ey}|label:E`;
+    const markers = [
+      `type:d|size:mid|pos:${sx} ${sy}|label:S`,
+      ...waypoints.map((wp, index) => `type:d|size:mid|pos:${wp.x} ${wp.y}|label:W${index + 1}`),
+      `type:d|size:mid|pos:${ex} ${ey}|label:E`
+    ];
+
+    const markerQuery = markers.map((marker) => `&markers=${marker}`).join("");
+
+    const routePoints = waypoints.length
+      ? [`${sx} ${sy}`, ...waypoints.map((wp) => `${wp.x} ${wp.y}`), `${ex} ${ey}`]
+      : [];
+
+    const pathQuery = routePoints.length
+      ? `&path=strokeColor:0x1F78FFDD|strokeWeight:6|strokeStyle:solid|${routePoints.join("|")}`
+      : "";
+
+    const api = `https://naveropenapi.apigw.ntruss.com/map-static/v2/raster?w=800&h=480&scale=2${markerQuery}${pathQuery}`;
 
     const r = await fetch(api, {
       headers: {
@@ -24,6 +56,20 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     });
 
     const h = new Headers(r.headers);
-    h.set("cache-control", "public, max-age=600");
+    const cacheControl = "public, max-age=600, s-maxage=600";
+    h.set("cache-control", cacheControl);
+    const varyValues = new Set(
+      (h.get("vary") || "")
+        .split(",")
+        .map((token) => token.trim())
+        .filter(Boolean)
+    );
+    varyValues.add("Origin");
+    h.set("vary", Array.from(varyValues).join(", "));
+
+    if (waypoints.length) {
+      const routeSignature = [`${sx},${sy}`, ...waypoints.map((wp) => `${wp.x},${wp.y}`), `${ex},${ey}`].join("|");
+      h.set("etag", `"route:${routeSignature}"`);
+    }
     return new Response(r.body, { status: r.status, headers: h });
   };


### PR DESCRIPTION
## Summary
- allow the static map API proxy to accept waypoint query parameters and render labelled waypoint markers
- draw a connecting path between start, waypoint, and end coordinates with custom styling while limiting the number of waypoints to avoid long URLs
- tighten caching headers, including s-maxage and an ETag derived from the requested route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb8c7840483318e7f913b335760e7