### PR TITLE
feat: add waypoint support to express route flow

### DIFF
--- a/functions/api/directions.ts
+++ b/functions/api/directions.ts
@@ -5,6 +5,7 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     const sy = u.searchParams.get("startY");
     const ex = u.searchParams.get("endX");
     const ey = u.searchParams.get("endY");
+    const waypoints = (u.searchParams.get("waypoints") || "").trim();
     if (!sx || !sy || !ex || !ey) {
       return new Response(JSON.stringify({ error: "Missing coords" }), {
         status: 400, headers: { "content-type": "application/json; charset=utf-8" }
@@ -16,8 +17,11 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
 
     // ⚠️ Directions는 경도,위도(lon,lat) 순서
-    const api = `https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving`
-              + `?start=${sx},${sy}&goal=${ex},${ey}&option=trafast`;
+    let api = `https://naveropenapi.apigw.ntruss.com/map-direction/v1/driving`
+            + `?start=${sx},${sy}&goal=${ex},${ey}&option=trafast`;
+    if (waypoints) {
+      api += `&waypoints=${encodeURIComponent(waypoints)}`;
+    }
 
     const r = await fetch(api, {
       headers: {

--- a/public/map-summary.html
+++ b/public/map-summary.html
@@ -19,6 +19,12 @@
             <dt>출발지</dt>
             <dd data-field="start">-</dd>
           </div>
+          <div class="hidden" data-field-section="waypoints">
+            <dt>경유지</dt>
+            <dd>
+              <ol class="meta" data-role="waypoints"></ol>
+            </dd>
+          </div>
           <div>
             <dt>도착지</dt>
             <dd data-field="end">-</dd>


### PR DESCRIPTION
## Summary
- add waypoint management to the express page with reusable autocomplete suggestions and persisted route storage
- propagate waypoint-aware parameters to the directions API and map summary views, reusing stored trafast summary details
- update the standalone summary page and script to render saved waypoints and synchronise cached summaries

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcb8c2fc30833180977fe21d845992