### PR TITLE
Support NAVER geocode environment variable fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@ The serverless functions rely on several third-party map providers. Set the foll
 
 - `KAKAO_REST_KEY` – Kakao Local REST API key used for keyword and address search.
 - `NAVER_SEARCH_CLIENT_ID` / `NAVER_SEARCH_CLIENT_SECRET` – credentials for the Naver Local Search API.
-- `NAVER_GEOCODE_KEY_ID` / `NAVER_GEOCODE_KEY` – Naver Cloud Platform Map Geocode API credentials used to turn addresses returned from Local Search into coordinates.
+- `NAVER_GEOCODE_KEY_ID` / `NAVER_GEOCODE_KEY` – Naver Cloud Platform Map Geocode API credentials used to turn addresses returned from Local Search into coordinates. For backwards compatibility the code also accepts `NAVER_CLIENT_ID` / `NAVER_CLIENT_SECRET` and will fall back to those if the dedicated keys are not set.
 - `MAPBOX_TOKEN` – Mapbox access token for geocoding fallbacks.

--- a/functions/api/directions.ts
+++ b/functions/api/directions.ts
@@ -1,4 +1,9 @@
-export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_SECRET:string; }> =
+export const onRequestGet: PagesFunction<{
+  NAVER_GEOCODE_KEY_ID?: string;
+  NAVER_GEOCODE_KEY?: string;
+  NAVER_CLIENT_ID?: string;
+  NAVER_CLIENT_SECRET?: string;
+}> =
   async ({ request, env }) => {
     const u = new URL(request.url);
     const sx = u.searchParams.get("startX");
@@ -144,8 +149,10 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
     }
 
     const origin = request.headers.get("Origin") || `${u.protocol}//${u.host}`;
-    const keyId  = (env.NAVER_CLIENT_ID || "").trim();
-    const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
+    const keyId =
+      (env.NAVER_GEOCODE_KEY_ID || env.NAVER_CLIENT_ID || "").trim();
+    const keySec =
+      (env.NAVER_GEOCODE_KEY || env.NAVER_CLIENT_SECRET || "").trim();
 
     // ⚠️ Directions는 경도,위도(lon,lat) 순서
     const waypointQuery = waypointCoords

--- a/functions/api/geocode.ts
+++ b/functions/api/geocode.ts
@@ -10,8 +10,10 @@ function resolveBase(env: Record<string, string | undefined>, override?: NcpHost
 }
 
 export const onRequestGet: PagesFunction<{
-  NAVER_CLIENT_ID: string;
-  NAVER_CLIENT_SECRET: string;
+  NAVER_GEOCODE_KEY_ID?: string;
+  NAVER_GEOCODE_KEY?: string;
+  NAVER_CLIENT_ID?: string;
+  NAVER_CLIENT_SECRET?: string;
   NAVER_MAPS_HOST?: string;
 }> = async ({ request, env }) => {
   const u = new URL(request.url);
@@ -26,8 +28,9 @@ export const onRequestGet: PagesFunction<{
   const hostOverride = (u.searchParams.get("host") as NcpHost | null) || undefined;
 
   const origin = request.headers.get("Origin") || `${u.protocol}//${u.host}`;
-  const keyId  = (env.NAVER_CLIENT_ID || "").trim();
-  const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
+  const keyId =
+    (env.NAVER_GEOCODE_KEY_ID || env.NAVER_CLIENT_ID || "").trim();
+  const keySec = (env.NAVER_GEOCODE_KEY || env.NAVER_CLIENT_SECRET || "").trim();
 
   const path = `/map-geocode/v2/geocode?query=${encodeURIComponent(q)}`;
   const headers: HeadersInit = {

--- a/functions/api/reverse.ts
+++ b/functions/api/reverse.ts
@@ -1,5 +1,7 @@
 export const onRequestGet: PagesFunction<{
   KAKAO_REST_KEY?: string;
+  NAVER_GEOCODE_KEY_ID?: string;
+  NAVER_GEOCODE_KEY?: string;
   NAVER_CLIENT_ID?: string;
   NAVER_CLIENT_SECRET?: string;
 }> = async ({ request, env }) => {
@@ -21,8 +23,8 @@ export const onRequestGet: PagesFunction<{
   }
 
   // 네이버(클라우드)로 하고 싶다면:
-  const id  = (env.NAVER_CLIENT_ID || "").trim();
-  const sec = (env.NAVER_CLIENT_SECRET || "").trim();
+  const id = (env.NAVER_GEOCODE_KEY_ID || env.NAVER_CLIENT_ID || "").trim();
+  const sec = (env.NAVER_GEOCODE_KEY || env.NAVER_CLIENT_SECRET || "").trim();
   const r = await fetch(`https://naveropenapi.apigw.ntruss.com/map-reversegeocode/v2/gc?coords=${encodeURIComponent(x)},${encodeURIComponent(y)}&output=json&orders=roadaddr,addr`, {
     headers: { "X-NCP-APIGW-API-KEY-ID": id, "X-NCP-APIGW-API-KEY": sec }
   });

--- a/functions/api/static-map.ts
+++ b/functions/api/static-map.ts
@@ -1,4 +1,9 @@
-export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_SECRET:string; }> =
+export const onRequestGet: PagesFunction<{
+  NAVER_GEOCODE_KEY_ID?: string;
+  NAVER_GEOCODE_KEY?: string;
+  NAVER_CLIENT_ID?: string;
+  NAVER_CLIENT_SECRET?: string;
+}> =
   async ({ request, env }) => {
     const u = new URL(request.url);
     const sx = u.searchParams.get("startX");
@@ -26,8 +31,10 @@ export const onRequestGet: PagesFunction<{ NAVER_CLIENT_ID:string; NAVER_CLIENT_
       .slice(0, MAX_WAYPOINTS);
 
     const origin = request.headers.get("Origin") || `${u.protocol}//${u.host}`;
-    const keyId  = (env.NAVER_CLIENT_ID || "").trim();
-    const keySec = (env.NAVER_CLIENT_SECRET || "").trim();
+    const keyId =
+      (env.NAVER_GEOCODE_KEY_ID || env.NAVER_CLIENT_ID || "").trim();
+    const keySec =
+      (env.NAVER_GEOCODE_KEY || env.NAVER_CLIENT_SECRET || "").trim();
 
     const markers = [
       `type:d|size:mid|pos:${sx} ${sy}|label:S`,


### PR DESCRIPTION
## Summary
- update the Naver-backed API routes to read NAVER_GEOCODE_KEY_ID / NAVER_GEOCODE_KEY with a fallback to the legacy NAVER_CLIENT_* variables
- document the supported environment variables in the README

## Testing
- not run (missing valid Naver credentials in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dcbe4dc1788331ac10d90b64f2cfed