### PR TITLE
Allow backend to choose suggest provider

### DIFF
--- a/src/routes/ExpressPage.tsx
+++ b/src/routes/ExpressPage.tsx
@@ -54,7 +54,7 @@ export default function ExpressPage() {
    */
   async function suggest(q: string, signal?: AbortSignal): Promise<Addr[]> {
     if (q.trim().length < 2) return [];
-    const r = await fetch(`/api/suggest?q=${encodeURIComponent(q)}&provider=kakao`, { signal });
+    const r = await fetch(`/api/suggest?q=${encodeURIComponent(q)}`, { signal });
     if (!r.ok) {
       throw new Error("주소/장소 추천 중 오류가 발생했어요.");
     }


### PR DESCRIPTION
## Summary
- stop forcing the Kakao provider when fetching address suggestions
- allow the backend to decide which suggestion provider chain to use

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dcbf782600833196f15594dde7ca3e