### PR TITLE
Handle fetch failures in suggestion providers

### DIFF
--- a/functions/api/suggest.ts
+++ b/functions/api/suggest.ts
@@ -73,46 +73,56 @@ async function fromNaverLocal(q: string, env: SuggestEnv): Promise<Item[]> {
   const id = (env.NAVER_SEARCH_CLIENT_ID || "").trim();
   const sec = (env.NAVER_SEARCH_CLIENT_SECRET || "").trim();
   if (!id || !sec) return [];
-  const r = await fetch(
-    "https://openapi.naver.com/v1/search/local.json?display=10&query=" + encodeURIComponent(q),
-    { headers: { "X-Naver-Client-Id": id, "X-Naver-Client-Secret": sec } }
-  );
-  if (!r.ok) return [];
-  const j = await r.json().catch(() => ({} as any));
-  const raw = j.items || [];
-  const geocodeCache = new Map<string, Promise<{ x: number; y: number } | null>>();
-  const out: Item[] = [];
-  for (const it of raw) {
-    const title = String(it.title || "").replace(/<[^>]+>/g, "");
-    const subtitle = (it.roadAddress || it.address || "").trim();
-    if (!subtitle) continue;
-    let lookup = geocodeCache.get(subtitle);
-    if (!lookup) {
-      lookup = fromNaverGeocode(subtitle, env);
-      geocodeCache.set(subtitle, lookup);
+  try {
+    const r = await fetch(
+      "https://openapi.naver.com/v1/search/local.json?display=10&query=" + encodeURIComponent(q),
+      { headers: { "X-Naver-Client-Id": id, "X-Naver-Client-Secret": sec } }
+    );
+    if (!r.ok) return [];
+    const j = await r.json().catch(() => ({} as any));
+    const raw = j.items || [];
+    const geocodeCache = new Map<string, Promise<{ x: number; y: number } | null>>();
+    const out: Item[] = [];
+    for (const it of raw) {
+      const title = String(it.title || "").replace(/<[^>]+>/g, "");
+      const subtitle = (it.roadAddress || it.address || "").trim();
+      if (!subtitle) continue;
+      let lookup = geocodeCache.get(subtitle);
+      if (!lookup) {
+        lookup = fromNaverGeocode(subtitle, env);
+        geocodeCache.set(subtitle, lookup);
+      }
+      const coords = await lookup;
+      if (!coords) continue;
+      out.push({ type: "place", title, subtitle, x: coords.x, y: coords.y });
     }
-    const coords = await lookup;
-    if (!coords) continue;
-    out.push({ type: "place", title, subtitle, x: coords.x, y: coords.y });
+    return out;
+  } catch (err) {
+    console.debug?.("naver-local suggestion fetch failed", err);
+    return [];
   }
-  return out;
 }
 
 async function fromMapbox(q: string, env: SuggestEnv): Promise<Item[]> {
   const token = (env.MAPBOX_TOKEN || "").trim();
   if (!token) return [];
   const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(q)}.json?autocomplete=true&language=ko&limit=10&access_token=${token}`;
-  const r = await fetch(url);
-  if (!r.ok) return [];
-  const j = await r.json().catch(() => ({} as any));
-  const feats = j.features || [];
-  return feats.map((f: any) => ({
-    type: f.place_type?.[0] === "address" ? "address" : "place",
-    title: f.text_ko || f.text || f.place_name_ko || f.place_name,
-    subtitle: f.place_name_ko || f.place_name || "",
-    x: Number(f.center?.[0]),
-    y: Number(f.center?.[1]),
-  })).filter((it: Item) => Number.isFinite(it.x) && Number.isFinite(it.y));
+  try {
+    const r = await fetch(url);
+    if (!r.ok) return [];
+    const j = await r.json().catch(() => ({} as any));
+    const feats = j.features || [];
+    return feats.map((f: any) => ({
+      type: f.place_type?.[0] === "address" ? "address" : "place",
+      title: f.text_ko || f.text || f.place_name_ko || f.place_name,
+      subtitle: f.place_name_ko || f.place_name || "",
+      x: Number(f.center?.[0]),
+      y: Number(f.center?.[1]),
+    })).filter((it: Item) => Number.isFinite(it.x) && Number.isFinite(it.y));
+  } catch (err) {
+    console.debug?.("mapbox suggestion fetch failed", err);
+    return [];
+  }
 }
 
 function dedup(items: Item[], limit = 12): Item[] {


### PR DESCRIPTION
## Summary
- wrap the Naver Local and Mapbox suggestion fetch calls in try/catch blocks
- return an empty result set when either provider throws so the request can fall back to others
- log provider fetch failures for debugging without interrupting the aggregation loop

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcbf752b408331b7e3ff4067b88d58